### PR TITLE
Copyedit and fix typos

### DIFF
--- a/data/Map Midnight.txt
+++ b/data/Map Midnight.txt
@@ -1071,7 +1071,7 @@ planet "Wildland"
 planet Corpse
 	attributes uninhabited midnight
 	landscape land/mars0
-	description `Several asteroids have formed a cluster at this location. Perhaps they are all that remain of a destroyed planet that once occupied this orbital path. With no atmosphere and the danger of asteroid collisions, a heavy environental suit is necessary to explore the area.`
+	description `Several asteroids have formed a cluster at this location. Perhaps they are all that remain of a destroyed planet that once occupied this orbital path. With no atmosphere and the danger of asteroid collisions, a heavy environmental suit is necessary to explore the area.`
 	government Uninhabited
 	security 0
 
@@ -1102,7 +1102,7 @@ planet Fossil
 planet "Hell's Maw"
 	attributes uninhabited midnight
 	landscape land/lava8
-	description `This dying world has been cracked open. The cooled mantle still glows with rivers of lava and the core sheds an eerie light upon the rocky outcroppings. Strange interstellar creatures dart across the planet's innards, feasting on its exposed mineral deposits. While there are thin traces of various gasses forming a thin atmosphere, it is not enough to support a human. When the exposed core faces the sun, the heat below the edge of the broken crust exceeds recommended safety limits. With the additional dangers from the hazardous environent and wildlife, a heavy environmental suit is necessary to explore the area.`
+	description `This dying world has been cracked open. The cooled mantle still glows with rivers of lava and the core sheds an eerie light upon the rocky outcroppings. Strange interstellar creatures dart across the planet's innards, feasting on its exposed mineral deposits. While there are thin traces of various gasses forming a thin atmosphere, it is not enough to support a human. When the exposed core faces the sun, the heat below the edge of the broken crust exceeds recommended safety limits. With the additional dangers from the hazardous environment and wildlife, a heavy environmental suit is necessary to explore the area.`
 	government Uninhabited
 	security 0
 
@@ -1180,7 +1180,7 @@ planet Quiet
 planet "Rock Cluster"
 	attributes uninhabited midnight
 	landscape land/mars0
-	description `Several asteroids have formed a cluster at this location. Perhaps they are all that remain of a destroyed planet that once occupied this orbital path. With no atmosphere and the danger of asteroid collisions, a heavy environental suit is necessary to explore the area.`
+	description `Several asteroids have formed a cluster at this location. Perhaps they are all that remain of a destroyed planet that once occupied this orbital path. With no atmosphere and the danger of asteroid collisions, a heavy environmental suit is necessary to explore the area.`
 	government Uninhabited
 	security 0
 

--- a/data/drak midnight/Missions Gathering Specimens Liquid Metal.txt
+++ b/data/drak midnight/Missions Gathering Specimens Liquid Metal.txt
@@ -211,15 +211,15 @@ mission "Gathering Specimens: Liquid Metal Amalgam"
 	on offer
 		conversation
 			scene "outfit/rock scavenger meat"
-			`	You''ve won a bet and have been given the opportunity to eat Rock Scavenger for free at the spaceport bar and grill! Before you can take a bite, the communications device of everyone in the restaurant loudly beeps, vibrates, or otherwise alerts their owners that they have a message.`
+			`	You've won a bet and have been given the opportunity to eat Rock Scavenger for free at the spaceport bar and grill! Before you can take a bite, the communications device of everyone in the restaurant loudly beeps, vibrates, or otherwise alerts their owners that they have a message.`
 			choice
 				`	(Check your messages.)`
 			scene "outfit/liquid metal specimen"
-			`You check yours and are surprised to get a message from the Syndicate representative who you delivered the Liquid Metal sample to: "Greetings Captain <first> <last>. The liquid metal specimen was used to make the test model Amalgam ship, Mythreal. You were to be invited to help test the ship as previously discussed. If you are anywhere near the Paradise Planets, we advise you to head over there if you want to try and stop the Mythreal. Unlike our normal testing procedures, you are not forbidden from destroying or capturing this ship.`
+			`You check yours and are surprised to get a message from the Syndicate representative who you delivered the Liquid Metal sample to: "Greetings Captain <first> <last>. The liquid metal specimen was used to make the test model Amalgam ship, Mythreal. You are invited to help test the ship as previously discussed. If you are anywhere near the Paradise Planets, we advise you to head over there if you want to try and stop the Mythreal. Unlike our normal testing procedures, you are not forbidden from destroying or capturing this ship."`
 			choice
 				`	(That's strange. Why...)`
 			scene "scene/scene-amalgam1"
-			`As you are mulling over the odd message, someone watching the news display mutters, "Ghost Ship. You look up in time to see a Quicksilver destroy a Navy Cruiser.`
+			`As you are mulling over the odd message, someone watching the news display mutters, "Ghost Ship". You look up in time to see a Quicksilver destroy a Navy Cruiser.`
 			choice
 				`	(What the...)`
 			scene "scene/scene-amalgam2"
@@ -230,7 +230,7 @@ mission "Gathering Specimens: Liquid Metal Amalgam"
 		personality target entering vindictive marked unconstrained mute
 			confusion 10
 		ship "Amalgam" "Mythreal"
-		dialog `The Mythreal is no longer a threat. Return to origin and check if the authorities will reward you for your efforts.`
+		dialog `The Mythreal is no longer a threat. Return to <origin> and check if the authorities will reward you for your efforts.`
 	on visit
 		dialog `The Mythreal is still in orbit. Get back up there!`
 	on complete

--- a/data/drak midnight/Missions Gathering Specimens Liquid Metal.txt
+++ b/data/drak midnight/Missions Gathering Specimens Liquid Metal.txt
@@ -141,7 +141,7 @@ mission "Gathering Specimens: Liquid Metal"
 			`	You decide to keep the specimen instead of turning it in. Remember to keep it installed so it doesn't get mixed in with the regular cargo.`
 				decline
 			label reward
-			`	The Syndicate representative is very appreciative for the return of their stolen propery and grants you <payment> as reward. They aren't asking any questions. As for you...`
+			`	The Syndicate representative is very appreciative for the return of their stolen propery and grants you one million credits as reward. They aren't asking any questions. As for you...`
 			label questions
 			choice
 				`	"Did the Syndicate really make this?"`

--- a/data/drak midnight/Missions Gathering Specimens Liquid Metal.txt
+++ b/data/drak midnight/Missions Gathering Specimens Liquid Metal.txt
@@ -141,7 +141,7 @@ mission "Gathering Specimens: Liquid Metal"
 			`	You decide to keep the specimen instead of turning it in. Remember to keep it installed so it doesn't get mixed in with the regular cargo.`
 				decline
 			label reward
-			`	The Syndicate representative is very appreciative for the return of their stolen propery and grants you one million credits as reward. They aren't asking any questions. As for you...`
+			`	The Syndicate representative is very appreciative for the return of their stolen property and grants you one million credits as reward. They aren't asking any questions. As for you...`
 			label questions
 			choice
 				`	"Did the Syndicate really make this?"`

--- a/data/drak midnight/Missions Gathering Specimens.txt
+++ b/data/drak midnight/Missions Gathering Specimens.txt
@@ -1442,7 +1442,7 @@ mission "Gathering Specimens: Remnant Conclusion"
 			choice
 				`	"Sure."`
 				`	"Of course I will."`
-			`	You	prepare for the journey to <destination>.`
+			`	You prepare for the journey to <destination>.`
 				accept
 	npc accompany save
 		government Remnant
@@ -1458,7 +1458,7 @@ mission "Gathering Specimens: Remnant Conclusion"
 			`	Taely lands the Raptor. Before departing on a ship bound for Viminal, she signs, "I think you'll enjoy piloting the Raptor. The engines are very responsive."`
 			scene "scene/scene-raptorweapons"
 			`	Prefect Chilia arrives with a team ready to install the weapons systems. As you watch them unload the crates, you wonder how the different specimens contributed to each weapon's design.`
-			`	It doesn't take long for the team to finish. "The Raptor is ready for testing. May the Ebers burn bright for you, captain!" he sings.`
+			`	It doesn't take long for the team to finish. "The Raptor is ready for testing. May the Embers burn bright for you, captain!" he sings.`
 			
 ship "Raptor Prototype" "Raptor Prototype (unarmed)"
 	outfits

--- a/data/hai midnight/Missions Angry Squirrels.txt
+++ b/data/hai midnight/Missions Angry Squirrels.txt
@@ -294,7 +294,7 @@ mission "Angry Squirrels: Countermeasures 1"
 	on offer
 		require "Intrusion Countermeasures"
 		conversation
-			`One of the Unfettered approaches you. "I have heard that you can get access to exotic weapons. There is a rumor that Quarg ships have powerful internal weapons systems. Would you be able to sell me one? I can offer you <payment>."`	
+			`One of the Unfettered approaches you. "I have heard that you can get access to exotic weapons. There is a rumor that Quarg ships have powerful internal weapons systems. Would you be able to sell me one? I can offer you one million credits."`
 			scene "outfit/quarg countermeasures"
 			choice
 				`	"I don't have any to sell you."`

--- a/data/hai midnight/Missions Quantum Key Blade.txt
+++ b/data/hai midnight/Missions Quantum Key Blade.txt
@@ -764,11 +764,11 @@ mission "QKBlade: Bearer of The Blade 5"
 				has "captain of atrocity"
 
 			choice
-				`	Dodge.`
+				`	(Dodge.)`
 					goto activate
-				`	Parry.`
+				`	(Parry.)`
 					goto death
-				`	Strike.`
+				`	(Strike.)`
 					goto death
 
 			label death
@@ -779,11 +779,11 @@ mission "QKBlade: Bearer of The Blade 5"
 			`	You dodge your assailant and activate the Quantum Key Blade. You and Phantom both regard each other and now that you have a chance to get a better look, you see that she is an Alpha! What will you do?`
 			label qbattle
 			choice
-				`	Quantum strike.`
+				`	(Quantum strike.)`
 					goto qdeath
-				`	Quantum parry.`
+				`	(Quantum parry.)`
 					goto qparry
-				`	Quantum shift.`
+				`	(Quantum shift.)`
 					goto qshift
 
 			label qdeath
@@ -797,11 +797,11 @@ mission "QKBlade: Bearer of The Blade 5"
 			label qshift
 			`	You shift out of Quantum mode and Phantom's blade harmlessly passes through you. Your opponent almost loses her balance, but shifts out of Quantum mode to regain her footing. Both of you gasp for air as you consider your next move. What will you do?`
 			choice
-				`	Feint.`
+				`	(Feint.)`
 					goto fdeath
-				`	Strike.`
+				`	(Strike.)`
 					goto pstrike
-				`	Quantum shift.`
+				`	(Quantum shift.)`
 					goto reshift
 					
 			label fdeath
@@ -815,13 +815,13 @@ mission "QKBlade: Bearer of The Blade 5"
 			label pstrike
 			`	Your attack passes harmlessly through her as she shifts back into Quantum mode. What will you do?`
 			choice
-				`	Dodge.`
+				`	(Dodge.)`
 					goto dodge
-				`	Parry.`
+				`	(Parry.)`
 					goto death
-				`	Strike.`
+				`	(Strike.)`
 					goto death
-				`	Quantum shift.`
+				`	(Quantum shift.)`
 					goto mistake
 
 			label dodge
@@ -835,11 +835,11 @@ mission "QKBlade: Bearer of The Blade 5"
 
 			label "Midnight's Lost Orphan"
 			choice
-				`	Dodge.`
+				`	(Dodge.)`
 					goto activate
-				`	Parry.`
+				`	(Parry.)`
 					goto death
-				`	Strike.`
+				`	(Strike.)`
 					goto death
 				`	(Wield the terrifying power of Midnight's Lost Orphan.)`
 			scene "outfit/midnight lost orphan"
@@ -865,7 +865,7 @@ mission "QKBlade: Bearer of The Blade 5"
 			`	"To think that an Alpha got ahold of it! We must tighten the security on these artifacts," exclaims one elder.`
 			`	"Funding will be granted to the Museum of Galactic History for this purpose," replies another elder.`
 			`	"Once again, Captain <first> <last>, you have proven your friendship to the Hai," states a third elder.`
-			`	"A reward of <payment> for the return of the blade was planned, but we will just deposit that to your account.`
+			`	"A reward of <payment> for the return of the blade was planned, but we will just deposit that to your account."`
 	
 mission "QKBlade: Thief of Blades"
 	invisible

--- a/data/hai midnight/Missions Quantum Key Blade.txt
+++ b/data/hai midnight/Missions Quantum Key Blade.txt
@@ -162,7 +162,7 @@ mission "QKBlade: Quantum Key Blade 2"
 			choice
 				`	"How can I be of assistance?"`
 			scene "outfit/quantum key blade"
-			`	"The Unfettered warrior Gai Ro Nin has undertaken a quest to seek out the lost Quantum Key Blade, an ancient artifact from the era when our people waged war across the galaxy," another elder continues."`
+			`	"The Unfettered warrior Gai Ro Nin has undertaken a quest to seek out the lost Quantum Key Blade, an ancient artifact from the era when our people waged war across the galaxy," another elder continues.`
 			`	"That weapon has been lost for over a hundred millenia. Surely if it even still exists it would no longer work!" interjects a third elder.`
 			`	"The legendary artifacts are no mere cutting tools and were made with technology long since forgotten to our people. If there is any chance that the lost blade should fall into the hands of the Unfettered..." warns a fourth elder.`
 			`	"Putting aside the issue of the lost artifact," interrupts a fifth elder, "What of this new ship, the Kotetsu, that Gai has at his disposal? Is it a credible threat to us?"`

--- a/data/human midnight/Missions Ghost  Hunting.txt
+++ b/data/human midnight/Missions Ghost  Hunting.txt
@@ -377,34 +377,34 @@ mission "Ghost Hunting: Poltergeist King 1"
 			scene "scene/scene-sivael3cropflipdark"
 			choice
 				`	(Call out for a response.)`
-				`	(Leave)`
+				`	(Leave.)`
 					flee
 			`	There is no response.`
 			scene "scene/scene-sivael3cropflipdark"
 			choice
 				`	(Explore the derelict.)`
-				`	(Leave)`
+				`	(Leave.)`
 					flee
 			`	It's quiet. Suddenly, the air is filled with static as some speakers crackle on.`
 			`	"Five. Hee hee hee!"`
 			scene "scene/scene-sivael3cropflipdark"
 			choice
 				`	(Continue to explore.)`
-				`	(Leave)`
+				`	(Leave.)`
 					flee
 			`	You look through several more corridors and empty rooms.`
 			`	"Four. Ha ha ha!"`
 			scene "scene/scene-sivael3cropflipdark"
 			choice
 				`	(Continue to explore.)`
-				`	(Leave)`
+				`	(Leave.)`
 					flee
 			`	You find a storage room with some cargo containers.`
 			`	"Three. Hee hee hee!"`
 			scene "scene/scene-sivael3cropflipdark"
 			choice
 				`	(Search the containers.)`
-				`	(Leave)`
+				`	(Leave.)`
 					flee
 			`	You find the missing kids gagged and tied up inside a cargo container. "I'm here to rescue you!"`
 			`	"Two. Ho ho ho!"`
@@ -561,41 +561,41 @@ conversation "Funhouse in Flames"
 	scene "scene/scene-sivael3cropflipdark"
 	choice
 		`	(Call out for a response.)`
-		`	(Leave)`
+		`	(Leave.)`
 			flee
 	`	There is no response.`
 	scene "scene/scene-sivael3cropflipdark"
 	choice
 		`	(Explore the derelict.)`
-		`	(Leave)`
+		`	(Leave.)`
 			flee
 	`	It's quiet. Suddenly, the air is filled with static as some speakers crackle on.`
 	`	"Five. Hee hee hee!"`
 	scene "scene/scene-sivael3cropflipdark"
 	choice
 		`	(Continue to explore.)`
-		`	(Leave)`
+		`	(Leave.)`
 			flee
 	`	You look through several more corridors and empty rooms.`
 	`	"Four. Ha ha ha!"`
 	scene "scene/scene-sivael3cropflipdark"
 	choice
 		`	(Continue to explore.)`
-		`	(Leave)`
+		`	(Leave.)`
 			flee
 	`	You find a storage room with some cargo containers.`
 	`	"Three. Hee hee hee!"`
 	scene "scene/scene-sivael3cropflipdark"
 	choice
 		`	(Search the containers.)`
-		`	(Leave)`
+		`	(Leave.)`
 			flee
 	`	The containers are empty.`
 	`	"Two. Ho ho ho!"`
 	scene "scene/scene-sivael3cropflipdark"
 	choice
 		`	(Keep searching.)`
-		`	(Leave)`
+		`	(Leave.)`
 			flee
 	`	You look through several more corridors and empty rooms.`
 	`	"One and done!"`

--- a/data/human midnight/Missions Harvesting Human.txt
+++ b/data/human midnight/Missions Harvesting Human.txt
@@ -20,7 +20,7 @@ mission "Harvesting: Fossil Acquisitions"
 	on offer
 		require Fossil
 		dialog
-			`If there is any place in the galaxy to find a serious buyer for the alien fossil you found, this is definitely it. After asking around for a bit, you finally find an official who is interested in purchasing a fossil. You have to answer some questions about how you obtained the fossil, but the process is quick and simple. Once you complete the transaction, you will be short one fossil, but <payment> richer.`
+			`If there is any place in the galaxy to find a serious buyer for the alien fossil you found, this is definitely it. After asking around for a bit, you finally find an official who is interested in purchasing a fossil. You have to answer some questions about how you obtained the fossil, but the process is quick and simple. Once you complete the transaction, you will be short one fossil, but 400,000 credits richer.`
 	on accept
 		outfit Fossil -1
 		payment 400000
@@ -36,7 +36,7 @@ mission "Harvesting: Fossil Researcher"
 	on offer
 		require Fossil
 		dialog
-			`<planet> has a noticeable scientific community present. If there is any place in the galaxy to find a serious buyer for the alien fossil you found, this might be it. After asking around for a bit, you finally find a researcher who is interested in purchasing a fossil. You have to answer some questions about how you obtained the fossil, but the process is quick and simple. Once you complete the transaction, you will be short one fossil, but <payment> richer.`
+			`<planet> has a noticeable scientific community present. If there is any place in the galaxy to find a serious buyer for the alien fossil you found, this might be it. After asking around for a bit, you finally find a researcher who is interested in purchasing a fossil. You have to answer some questions about how you obtained the fossil, but the process is quick and simple. Once you complete the transaction, you will be short one fossil, but 300,000 credits richer.`
 	on accept
 		outfit Fossil -1
 		payment 300000
@@ -52,7 +52,7 @@ mission "Harvesting: Fossil Collector"
 	on offer
 		require Fossil
 		dialog
-			`The paradise worlds are filled with people who have more money than sense. If there is any place in the galaxy to quickly find a a rich sucker willing to pay ridiculous sums of money for the alien fossil you found, this could be it. After asking around for a bit, you finally find a collector who is interested in purchasing a fossil. Once you complete the transaction, you will be short one fossil, but <payment> richer.`
+			`The paradise worlds are filled with people who have more money than sense. If there is any place in the galaxy to quickly find a rich sucker willing to pay ridiculous sums of money for the alien fossil you found, this could be it. After asking around for a bit, you finally find a collector who is interested in purchasing a fossil. Once you complete the transaction, you will be short one fossil, but 200,000 credits richer.`
 	on accept
 		"reputation: Midnight Market" ++
 		outfit Fossil -1

--- a/data/human midnight/Missions Liberator Vindicator.txt
+++ b/data/human midnight/Missions Liberator Vindicator.txt
@@ -27,7 +27,7 @@ mission "SB-Labs Vindicator 1"
 			has "Oathbreaker Thermopylae: done"
 	on offer
 		dialog
-			`You receive a message from Barmy Edwards on Rust: "Hello Captain <first> <last>. I just finished outfitting a new prototype ship for Southbound Shipyards. Would you be interested in helping to test it out?`
+			`You receive a message from Barmy Edwards on Rust: "Hello Captain <first> <last>. I just finished outfitting a new prototype ship for Southbound Shipyards. Would you be interested in helping to test it out?"`
 	on complete
 		dialog
 			`Head for the shipyard when you are ready to meet Barmy Edwards and test the new ship he mentioned.`
@@ -145,7 +145,7 @@ mission "SB-Labs Vindicator 4"
 	on offer
 		conversation
 			`As you disembark, you see Barmy talking to a man wearing a Southbound Shipyards engineering uniform.`
-			`	Barmy waves you over. "Captain <last>, this is Ricardo Astillero from Southbound Shipyards R&D. He was just telling me the bad news.`
+			`	Barmy waves you over. "Captain <last>, this is Ricardo Astillero from Southbound Shipyards R&D. He was just telling me the bad news."`
 			`	"Wait, THE Captain <last>? The war hero?" Ricardo expresses his surprise.`
 			choice
 				`	"The one and only. So what's this bad news?"`
@@ -160,7 +160,7 @@ mission "SB-Labs Vindicator 4"
 			`	Ricardo has a grim look on his face. "Take the ship and leave. I'll tell them I tricked you into taking it for more testing. Please, we worked so hard on this..."`
 			`	Barmy turns to you. "Even so, there might still be some repurcussions to your reputation. It's your choice, captain."`
 			choice
-				`	"Alright, it's a big risk, but I'll take it.`
+				`	"Alright, it's a big risk, but I'll take it."`
 					goto liberator
 				`	"Sorry, no. I'm not willing to take this much risk for someone I just met."`
 					goto risk
@@ -182,7 +182,7 @@ mission "SB-Labs Vindicator 4"
 	on enter
 		conversation
 			scene "scene/scene-navyfleet"
-			`A squad of Militia ships are launching from the planet. But they're not after you. Instead, they're targetting a large pirate fleet that just entered the system! It looks like the pirate are starting a siege. Time for the Vindicator to prove its worth!`
+			`A squad of Militia ships are launching from the planet. But they're not after you. Instead, they're targetting a large pirate fleet that just entered the system! It looks like the pirates are starting a siege. Time for the Vindicator to prove its worth!`
 				accept
 
 	on enter
@@ -258,7 +258,7 @@ mission "Oathbreaker Liberator 1"
 		not "SB-Labs Vindicator 1: offered"
 	on offer
 		dialog
-			`You receive a message from Barmy Edwards on Rust: "Hello Captain <first> <last>. I just finished outfitting a new prototype ship for Southbound Shipyards. Would you be interested in helping to test it out?`
+			`You receive a message from Barmy Edwards on Rust: "Hello Captain <first> <last>. I just finished outfitting a new prototype ship for Southbound Shipyards. Would you be interested in helping to test it out?"`
 	on complete
 		dialog
 			`Head for the shipyard when you are ready to meet Barmy Edwards and test the new ship he mentioned.`

--- a/data/human midnight/Missions Oath Breaker.txt
+++ b/data/human midnight/Missions Oath Breaker.txt
@@ -846,7 +846,7 @@ mission "Oathbreaker Metallic Asteroids 3"
 	on offer
 		conversation
 			`When you land, you receive a message from Amy, the girl you helped to terraform Rand and Tundra.`
-			`	"I hope everything is going well, Captain. I was wondering if your friend was able to make use of the information I gave him. He seemed very excited about reading our work on 'Reducing Terraforming Expenses Through Equilibrium Mapping,' and said that you were the one who brought our work to his attention."`
+			`	"I hope everything is going well, Captain. I was wondering if your friend was able to make use of the information I gave him. He seemed very excited about reading our work on 'Reducing Terraforming Expenses Through Equilibrium Mapping' and said that you were the one who brought our work to his attention."`
 			`	Strange. You don't remember referring anyone to Amy and Nolan regarding their terraforming research.`
 				decline
 

--- a/data/human midnight/Outfits Human.txt
+++ b/data/human midnight/Outfits Human.txt
@@ -195,7 +195,7 @@ outfit "Liquid Metal Hull"
 	"integrated systems" 1
 	"reinstall" -1
 	"unplunderable" 1
-	description `Made with Korath nanomachine technology. It's ability to regenerate the hull is unparalleld.`
+	description `Made with Korath nanomachine technology. Its ability to regenerate the hull is unparalleled.`
 
 
 

--- a/data/quarg midnight/Missions Cartography Begin.txt
+++ b/data/quarg midnight/Missions Cartography Begin.txt
@@ -391,7 +391,7 @@ event "Diyu reveal"
 
 mission "Cartography: Quarg Hitchhiker 3"
 	name "Underworld Hitchhiker"
-	description "Bring Quash to an underground pirate hideout on <planet> to complete a trade. Then return it to <origin>."
+	description "Bring Quash to an underground pirate hideout on <planet> to complete a trade. Then return to <origin>."
 	source "Wang Xiang Tai"
 	destination "Naihe Qiao"
 	passengers 1
@@ -442,7 +442,7 @@ event "Diyu hyperlinks"
 mission "Cartography: Quarg Hitchhiker 4"
 	landing
 	name "Underworld Hitchhiker"
-	description "Bring Quash to an underground pirate hideout on <planet> to complete a trade. Then return it to <origin>."
+	description "Bring Quash to an underground pirate hideout on <origin> to complete a trade. Then return to <planet>."
 	source "Naihe Qiao"
 	destination "Wang Xiang Tai"
 	passengers 1

--- a/data/quarg midnight/Missions Cartography Begin.txt
+++ b/data/quarg midnight/Missions Cartography Begin.txt
@@ -135,9 +135,9 @@ mission "Cartography: Quarg Hitchhiker 2"
 			`	Soon after you enter, your eyes adjust to the low light. The four corners of the room are occupied by alien devices that provide the only internal light sources. On the floor is a pouch, a briefcase, and a series of bloodstains.`
 			`	"Sorry about the mess." Quash's voice emanates from a speaker in the ceiling. "The business associate who helped me acquire this vessel chose to alter the terms of our agreement. He chose poorly. I'm certain you are a trustworthy businessman who would not engage in such duplicitous behavior. Your payment of <payment> is in the pouch on the floor. Go ahead, you've earned it."`
 			choice
-				`	(Take the pouch)`
+				`	(Take the pouch.)`
 					goto departure
-				`	(Take the briefcase)`
+				`	(Take the briefcase.)`
 				`	(Take both.)`
 				
 			`	As soon as you touch the briefcase, the entry hatch slams shut. "Tsk. tsk. Captain <first> <last>, I had hoped we could continue to do business in the future." The four devices in the corners of the room are glowing with an eerie light. The heat in the room is also rising. "However, I can't have business associates who are unable to follow simple instructions." Your hair and skin are burning as you bleed out on the floor. Quash's words are drowned out by your screams. After a few moments, the room is dark and silent once again.`

--- a/data/quarg midnight/Missions Cartography Begin.txt
+++ b/data/quarg midnight/Missions Cartography Begin.txt
@@ -241,7 +241,7 @@ mission "Cartography: The Map (Coalition)"
 				`	(Yes.)`
 				`	(Not now.)`
 					defer
-			`	After asking around, you're directed to the astronomy department of a local educational center. "Strange, it is," comments a professor,"A Saryd map this is. Familiar with these stars we are not." They ask you for more information about how and where you obtained the map. After listening to your story, they come to a conclusion. "An exploratory mission, it probably was. Before returning, unfortunate crash they likely had." Without a point of reference to guide them, they are unable to extrapolate the current position of these star systems.`
+			`	After asking around, you're directed to the astronomy department of a local educational center. "Strange, it is," comments a professor. "A Saryd map this is. Familiar with these stars we are not." They ask you for more information about how and where you obtained the map. After listening to your story, they come to a conclusion. "An exploratory mission, it probably was. Before returning, unfortunate crash they likely had." Without a point of reference to guide them, they are unable to extrapolate the current position of these star systems.`
 				decline
 
 
@@ -451,7 +451,7 @@ mission "Cartography: Quarg Hitchhiker 4"
 	on offer
 		conversation
 			`Quash directs you to a certain canyon. In a deep secluded area surrounded by steep canyon walls, you find a tunnel large enough to squeeze your ship through...`
-			`	You can't help but feel a tinge of claustrophobia as you navigate your ship throught the narrow tunnels. The occasional stalactite pierces your shields and scrapes your hull. The damage is inconsequential, but you still cringe at the thought of the damage to the paint. After an hour the tunnel opens up into a large cavern that has several other tunnels leading away from it. You've finally reached your destination.`
+			`	You can't help but feel a tinge of claustrophobia as you navigate your ship through the narrow tunnels. The occasional stalactite pierces your shields and scrapes your hull. The damage is inconsequential, but you still cringe at the thought of the damage to the paint. After an hour the tunnel opens up into a large cavern that has several other tunnels leading away from it. You've finally reached your destination.`
 			scene "thumbnail/hai shield beetle"
 			`	"Land here," Quash instructs. Soon after, a Hai shield beetle descends from a tunnel farther up. "Relax captain. These people have brought something for me. Please open the hatch so that I may meet them.`
 			choice
@@ -516,7 +516,7 @@ mission "Cartography: Quarg Hitchhiker 5"
 			choice
 				`	"Is this the system you were looking for?"`
 
-			`	"No. But I know where to find that data. Would you be interested in escorting me there.?"`
+			`	"No. But I know where to find that data. Would you be interested in escorting me there?"`
 			choice
 				`	"Sure. I'd also like to learn the location of the system you are searching for."`
 				`	"Sorry, I have other things to do."`
@@ -780,7 +780,7 @@ mission "Cartography: Midnight's Lost Orphan"
 				`	(Track the moving object.)`
 			
 			scene "outfit/midnight lost orphan"
-			`	From the way it acts, you're certain this is an alien life form. It looks translucent, as if it consists of a hazy mist. The creature seems to be aware of your presence and you suspect it is studying you. Slowly, it starts to descend towards you."`
+			`	From the way it acts, you're certain this is an alien life form. It looks translucent, as if it consists of a hazy mist. The creature seems to be aware of your presence and you suspect it is studying you. Slowly, it starts to descend towards you.`
 			`	"Back away from the creature, Captain <first> <last>." Quash enters the chamber and gives you a stern warning. The mysterious creature hesitates, seeming to observe the actions of its two guests.`
 			choice
 				`	(Do as Quash says. Back away from the creature.)`
@@ -813,7 +813,7 @@ mission "Cartography: Midnight's Lost Orphan"
 			choice
 				`	(Grab the compass and run.)`
 					goto run
-				`	(Wait to see what happens to Quash)`
+				`	(Wait to see what happens to Quash.)`
 
 			scene "scene/scene-station5blood"
 			`	After a while, Quash stops screaming. It calmly stands up and stretches its limbs. The bullet holes are gone, the wounds completely healed. The Quarg then begins to laugh. "Finally reunited! How many centuries have I waited!?!" It looks over at you. "Still here?" It makes a gesture and you are telekinietically lifted off the ground. You feel a strange pressure crushing your body, your bones, your internal organs... "Oops. I suppose it has been a while since I've had access to these powers..."`

--- a/data/remnant midnight/Missions Harvesting Remnant.txt
+++ b/data/remnant midnight/Missions Harvesting Remnant.txt
@@ -13,7 +13,7 @@
 
 mission "Harvesting Quantumium Research"
 	name "Quantumium Research"
-	description "Deliver 10 Quantumium stones to Aeolus on <destination>. Payment is payment."
+	description "Deliver 10 Quantumium stones to Aeolus on <destination>. Payment is <payment>."
 	source Viminal
 	to offer
 		has "Remnant: Keystone Research 1: done"

--- a/data/wanderer midnight/Genesis.txt
+++ b/data/wanderer midnight/Genesis.txt
@@ -711,7 +711,7 @@ event "Genesis Colony"
 				period 47.3937
 				offset 196.692
 	planet "The Garden"
-		spaceport `The Childen of The Garden have constructed a simple spaceport, with runways, landing/launching pads, and hangars. Though they haven't devloped a Hyperdrive, they still use hyperspace fuel in their engines and are able to refuel your ship.`
+		spaceport `The Childen of The Garden have constructed a simple spaceport, with runways, landing/launching pads, and hangars. Though they haven't developed a Hyperdrive, they still use hyperspace fuel in their engines and are able to refuel your ship.`
 		add description `They have set up an outfitter. Many of the outfits are similar to equivalents you can find in human space.`
 		outfitter "Genesis"
 	planet "The Gate"
@@ -779,7 +779,7 @@ event "Genesis Cryoships"
 				offset 196.692
 	planet "The Garden"
 		landscape land/nasa4
-		spaceport `The Childen of The Garden have constructed a new spaceport, with larger landing/launching pads and facilities to handle their new Cryoships. Though they haven't devloped a Hyperdrive, they still use hyperspace fuel in their engines and are able to refuel your ship.`
+		spaceport `The Childen of The Garden have constructed a new spaceport, with larger landing/launching pads and facilities to handle their new Cryoships. Though they haven't developed a Hyperdrive, they still use hyperspace fuel in their engines and are able to refuel your ship.`
 	planet "The Gate"
 		landscape land/nasa2
 		description `The Childen of The Garden have developed this spacecolony into a thriving city.`

--- a/data/wanderer midnight/Missions Storm Seeker.txt
+++ b/data/wanderer midnight/Missions Storm Seeker.txt
@@ -19,7 +19,7 @@ mission "Storm Seeker Raider 1"
 			scene "thumbnail/raider"
 			`You are surprised to find one of these parked here. An entry hatch was left open, inviting you into the dark interior of the ship.`
 			choice
-				`	Enter.`
+				`	(Enter.)`
 			scene "scene/scene-sivael6cropred"
 			`	As you explore the ship, you realize that the crew was human. You are able to figure this out, because their dead bodies are strewn about. From their attire and equipment, they were probably pirates. They died violently. A mutiny, perhaps? After some more exploration, you note that the jump drive is missing. Maybe it was stolen by another crew. The mystery will have to be left unsolved.`
 			`	This ship isn't going anywhere in its current condition, but if you return with an extra jump drive, it can be salvaged.`


### PR DESCRIPTION
This PR fixes some more typos and substitution issues. For missions with the `payment` listed under `on accept`, the substitution for `<payment>` doesn't seem to work. Some of these payments are fixed payments, so I've hard-coded the amounts. For example, `<payment>` → `one million credits` in Missions Angry Squirrels.

Some of the typos were cherry-picked over from #2. For your sake, I suggest using GitHub's merge functionality to avoid having to copy the changes one-by-one and to avoid missing out any suggestions. Feel free to make changes to the amendments by going to the "Files changed" tab and, under each file's dropdown, "Edit file".